### PR TITLE
Added a special latest tag for Oxide build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ based on the latest version of my Rust Docker image.
 
 The tag of these images is prefixed with `oxide-build`. So look out for these
 [tags on Docker Hub](https://hub.docker.com/r/pfeiffermax/rust-game-server/tags) if you want to run Rust with Oxide.
+There is also a `latest-oxide` tag, so you can use this to always run an up-to-date Docker image with Oxide.
 
 This image aims to be a solid base to run any plugin. So please drop me a line if you are missing any Debian package
 for a plugin.

--- a/build/oxide/publish.py
+++ b/build/oxide/publish.py
@@ -59,7 +59,7 @@ def main(
 
         tag = create_oxide_tag(current_oxide_build_id)
         image_reference_version: str = get_image_reference(registry, tag)
-        image_reference_latest: str = get_image_reference(registry, "latest")
+        image_reference_latest: str = get_image_reference(registry, "latest-oxide")
         if github_ref_name:
             cache_to: str = f"type=gha,mode=max,scope={github_ref_name}"
             cache_from: str = f"type=gha,scope={github_ref_name}"


### PR DESCRIPTION
These two different build were overwriting each other's latest tag.